### PR TITLE
Default factory

### DIFF
--- a/src/type_conversion_dict/type_conversion_dict.py
+++ b/src/type_conversion_dict/type_conversion_dict.py
@@ -102,7 +102,7 @@ class TypeConversionDict(dict[_K, _V]):
     def get(  # type: ignore[no-untyped-def]
         self,
         key,
-        default=_missing,  # Default to None
+        default=None,
         *,
         default_factory=_missing,
         type=_missing,  # Default to no type conversion
@@ -142,7 +142,7 @@ class TypeConversionDict(dict[_K, _V]):
         except KeyError:
             if required is _missing or not required:
                 # required is False. return default
-                if default is _missing or default is None:
+                if default is None:
                     # default is not provided. what about default_factory?
                     if default_factory is _missing:
                         return None
@@ -154,7 +154,7 @@ class TypeConversionDict(dict[_K, _V]):
             raise
 
         # Check for rv already being the default value. If so, return it without type conversion
-        if default is _missing or default is None:
+        if default is None:
             # default value is missing. how about the default_factory though?
             if default_factory is _missing:
                 if rv is None:
@@ -180,7 +180,7 @@ class TypeConversionDict(dict[_K, _V]):
             except ValueError:
                 if required is _missing or not required:
                     # Type conversion failed. Return default
-                    if default is _missing or default is None:
+                    if default is None:
                         # no default. how about default_factory?
                         if default_factory is _missing:
                             return None

--- a/src/type_conversion_dict/type_conversion_dict.py
+++ b/src/type_conversion_dict/type_conversion_dict.py
@@ -106,7 +106,7 @@ class TypeConversionDict(dict[_K, _V]):
         *,
         default_factory=_missing,
         type=_missing,  # Default to no type conversion
-        required=_missing,  # Default to False
+        required=False,  # Default to False
     ):
         """Return the default value if the requested data doesn't exist.
         If `type` is provided and is a callable it should convert the value,
@@ -140,7 +140,7 @@ class TypeConversionDict(dict[_K, _V]):
         try:
             rv = self[key]
         except KeyError:
-            if required is _missing or not required:
+            if not required:
                 # required is False. return default
                 if default is None:
                     # default is not provided. what about default_factory?
@@ -158,7 +158,7 @@ class TypeConversionDict(dict[_K, _V]):
             # default value is missing. how about the default_factory though?
             if default_factory is _missing:
                 if rv is None:
-                    if required is _missing or not required:
+                    if not required:
                         return None
                     else:
                         raise ValueError(f"Required key {key} is None")
@@ -178,7 +178,7 @@ class TypeConversionDict(dict[_K, _V]):
             try:
                 rv = type(rv)  # pyright: ignore[reportCallIssue]
             except ValueError:
-                if required is _missing or not required:
+                if not required:
                     # Type conversion failed. Return default
                     if default is None:
                         # no default. how about default_factory?

--- a/src/type_conversion_dict/type_conversion_dict.py
+++ b/src/type_conversion_dict/type_conversion_dict.py
@@ -135,6 +135,8 @@ class TypeConversionDict(dict[_K, _V]):
         """
 
         __tracebackhide__ = True
+
+        # Get the value from self and handle what to do if it's not found
         try:
             rv = self[key]
         except KeyError:
@@ -297,6 +299,8 @@ class TypeConversionDict(dict[_K, _V]):
         """
 
         __tracebackhide__ = True
+
+        # Get the value from self and handle what to do if it's not found
         try:
             rv = self[key]
         except KeyError:
@@ -345,7 +349,7 @@ class TypeConversionDict(dict[_K, _V]):
                 if default is _missing:
                     # No default, but lets check for default_factory
                     if default_factory is _missing:
-                        # No default, therefore behave as if required is True by default
+                        # No default or default_factory, therefore behave as if required is True by default
                         if required is _missing or required:
                             raise
                         return None

--- a/src/type_conversion_dict/type_conversion_dict.py
+++ b/src/type_conversion_dict/type_conversion_dict.py
@@ -104,7 +104,7 @@ class TypeConversionDict(dict[_K, _V]):
         key,
         default=None,
         *,
-        default_factory=_missing,
+        default_factory=_missing,  # Default to no default_factory
         type=_missing,  # Default to no type conversion
         required=False,  # Default to False
     ):

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -320,3 +320,20 @@ def test_get_with_default_and_default_factory() -> None:
     _value = d.get("bar", "default", default_factory=df, required=False)  # type: ignore
     assert _value == "default"
     assert i == 0  # default factory should not run
+
+
+def test_default_factory_classes() -> None:
+    d = TypeConversionDict(foo="42")
+
+    # Make sure we can instantiate basic types
+    value_2: list | str = d.get("bar", default_factory=list)
+    assert_type(value_2, list | str)
+    assert value_2 == []
+
+    # Make sure we can instantiate classes
+    class MyClass:
+        pass
+
+    value_3: MyClass | str = d.get("bar", default_factory=MyClass)
+    assert_type(value_3, MyClass | str)
+    assert isinstance(value_3, MyClass)

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -326,14 +326,14 @@ def test_default_factory_classes() -> None:
     d = TypeConversionDict(foo="42")
 
     # Make sure we can instantiate basic types
-    value_2: list | str = d.get("bar", default_factory=list)
-    assert_type(value_2, list | str)
+    value_2: Union[list, str] = d.get("bar", default_factory=list)
+    assert_type(value_2, Union[list, str])
     assert value_2 == []
 
     # Make sure we can instantiate classes
     class MyClass:
         pass
 
-    value_3: MyClass | str = d.get("bar", default_factory=MyClass)
-    assert_type(value_3, MyClass | str)
+    value_3: Union[MyClass, str] = d.get("bar", default_factory=MyClass)
+    assert_type(value_3, Union[MyClass, str])
     assert isinstance(value_3, MyClass)


### PR DESCRIPTION
Add `default_factory` kwarg for lazy evaluation of expensive init. Most work is done in tests and by the type checker.